### PR TITLE
Prevent unnecesarry compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.updateimpact"
 
 name := "updateimpact-sbt-plugin"
 
-version := "2.1.1"
+version := "2.1.6"
 
 sbtPlugin := true
 

--- a/src/main/scala/com/updateimpact/CreateModuleDependencies.scala
+++ b/src/main/scala/com/updateimpact/CreateModuleDependencies.scala
@@ -18,7 +18,8 @@ class CreateModuleDependencies(ivy: Ivy, log: Logger, rootMd: ModuleDescriptor,
 
   def forClasspath(cfg: Configuration, cpCfg: Configuration, cp: Classpath): ModuleDependencies = {
 
-    val (classpathDepIds, depsWithoutModuleIDs) = depIdsFromClasspath(cfg, cp)
+    val (depsWithModuleIds, depsWithoutModuleIDs) = depIdsFromClasspath(cfg, cp)
+    val classpathDepIds = rootId :: depsWithModuleIds
 
     val classpathDepVersions = classpathDepIds.map { id => OrgAndName(id) -> id.getVersion }.toMap
 

--- a/src/main/scala/com/updateimpact/CreateModuleDependencies.scala
+++ b/src/main/scala/com/updateimpact/CreateModuleDependencies.scala
@@ -93,7 +93,7 @@ class CreateModuleDependencies(ivy: Ivy, log: Logger, rootMd: ModuleDescriptor,
         case s => s
       })
     }.toMap
-    def getModuleInfo(id: DependencyId): Option[(ModuleDescriptor, Seq[DependencyDescriptor])] =
+    def getIvyModuleInfo(id: DependencyId): Option[(ModuleDescriptor, Seq[DependencyDescriptor])] =
       moduleInfoCache.get(id) match {
         case Some(r) => r
         case None =>
@@ -103,7 +103,7 @@ class CreateModuleDependencies(ivy: Ivy, log: Logger, rootMd: ModuleDescriptor,
       }
 
     // Map from id of a dependency to the configurations in which it is included
-    var depsCfgs: Map[DependencyId, Set[String]] = Map(rootId -> includedConfigs.toSet)
+    var depsToConfigsMap: Map[DependencyId, Set[String]] = Map(rootId -> includedConfigs.toSet)
 
     // Pattern for extracting Ivy configuration mappings with a fallback
     val FallbackConfig = """(.*)\((.*)\)""".r
@@ -112,35 +112,33 @@ class CreateModuleDependencies(ivy: Ivy, log: Logger, rootMd: ModuleDescriptor,
      * For the given dependency and id, resolves the config specification to a list of valid configuration
      * names of the dependency. The specification can be a fallback, * or config name
      */
-    def resolveConfig(id: DependencyId, cfgSpec: String): Set[String] = {
-      val cfgs = getModuleInfo(id).map(_._1.getConfigurations.toSet).getOrElse(Set())
-      lazy val cfgNames = cfgs.map(_.getName)
+    def resolveConfig(dependency: DependencyId, configName: String): Set[String] = {
+      val configs = getIvyModuleInfo(dependency).map(_._1.getConfigurations.toSet).getOrElse(Set())
+      lazy val configNames = configs.map(_.getName)
 
-      (cfgSpec match {
+      (configName match {
         case FallbackConfig(default, fallback) =>
-          if (cfgNames.contains(default)) Set(default) else { if (cfgNames.contains(fallback)) Set(fallback) else Set() }
-        case "*" => cfgNames - "optional"
-        case _ => Set(cfgSpec)
-      }).flatMap((cfg: String) => getConfigsClosure(cfg, cfgs))
+          if (configNames.contains(default)) Set(default) else { if (configNames.contains(fallback)) Set(fallback) else Set() }
+        case "*" => configNames - "optional"
+        case _ => Set(configName)
+      }).flatMap((cfg: String) => getConfigsClosure(cfg, configs))
     }
 
     def doPropagateCfgs(id: DependencyId): Unit = {
-      val cfgs = depsCfgs.getOrElse(id, Set())
-      val cfgsArray = cfgs.toArray
+      val dependencyConfigs = depsToConfigsMap.getOrElse(id, Set()).toArray
 
-      val deps = getModuleInfo(id).map(_._2).getOrElse(Nil)
+      val subDependenciesIvyDescriptors = getIvyModuleInfo(id).map(_._2).getOrElse(Nil)
       var changed = Set.empty[DependencyId]
 
-      deps.foreach { dep =>
-        val depId = toDepId(dep.getDependencyRevisionId)
-        val depCfgs = dep.getDependencyConfigurations(cfgsArray).toSet.flatMap(resolveConfig(depId, _: String))
+      subDependenciesIvyDescriptors.foreach { subDependencyDescriptor =>
+        val subDependency = toDepId(subDependencyDescriptor.getDependencyRevisionId)
+        val ivySubDependencyConfigs = subDependencyDescriptor.getDependencyConfigurations(dependencyConfigs).toSet.flatMap(resolveConfig(subDependency, _: String))
+        val subDependencyConfigs = depsToConfigsMap.getOrElse(subDependency, Set())
+        val mergedSubDependencyConfigs = subDependencyConfigs ++ ivySubDependencyConfigs
 
-        val current = depsCfgs.getOrElse(depId, Set())
-        val modified = current ++ depCfgs
-
-        if (modified.size > current.size) {
-          depsCfgs += depId -> modified
-          changed += depId
+        if (mergedSubDependencyConfigs.size > subDependencyConfigs.size) {
+          depsToConfigsMap += subDependency -> mergedSubDependencyConfigs
+          changed += subDependency
         }
       }
 
@@ -156,7 +154,7 @@ class CreateModuleDependencies(ivy: Ivy, log: Logger, rootMd: ModuleDescriptor,
           Nil
         case Some((desc, ds)) =>
           val r = ds.filter { d =>
-            depsCfgs.get(toDepId(d.getDependencyRevisionId)).exists(_.nonEmpty)
+            depsToConfigsMap.get(toDepId(d.getDependencyRevisionId)).exists(_.nonEmpty)
           }.map(d => replaceVersionIfMatchesCp(toDepId(d.getDependencyRevisionId)))
           r
       })

--- a/src/main/scala/com/updateimpact/Plugin.scala
+++ b/src/main/scala/com/updateimpact/Plugin.scala
@@ -72,7 +72,7 @@ object Plugin extends AutoPlugin {
 
     ivySbt.value.withIvy(log) { ivy =>
       val cmd = new CreateModuleDependencies(ivy, log, md, pitii, ur)
-      cmd.forClasspath(cfg, classpathConfiguration.value, fullClasspath.value)
+      cmd.forClasspath(cfg, classpathConfiguration.value, dependencyClasspath.value)
     }
   }
 

--- a/src/main/scala/com/updateimpact/testing/ReportToString.scala
+++ b/src/main/scala/com/updateimpact/testing/ReportToString.scala
@@ -6,19 +6,19 @@ import scala.collection.JavaConversions._
 object ReportToString {
   def toString(dr: DependencyReport): String = {
     dr.getModuleDependencies.groupBy(_.getConfig).toList.sortBy(_._1).map { case (config, modules) =>
-        modules.toList.sortBy(_.getModuleId.toString).map { m =>
-          val h1 = s"${m.getModuleId} in ${m.getConfig}\n"
+      modules.toList.sortBy(_.getModuleId.toString).map { m =>
+        val h1 = s"${m.getModuleId} in ${m.getConfig}\n"
 
-          h1 + m.getDependencies.toList.sortBy(_.getId.toString).map { d =>
-            val h2 = s"   ${d.getId}${if (d.getEvictedByVersion != null) s" evicted by ${d.getEvictedByVersion}" else ""}"
+        h1 + m.getDependencies.toList.sortBy(_.getId.toString).map { d =>
+          val h2 = s"   ${d.getId}${if (d.getEvictedByVersion != null) s" evicted by ${d.getEvictedByVersion}" else ""}"
 
-            val chld = d.getChildren.toList.sortBy(_.toString).map { c =>
-              "      " + c.toString
-            }
+          val chld = d.getChildren.toList.sortBy(_.toString).map { c =>
+            "      " + c.toString
+          }
 
-            if (chld.isEmpty) h2 else h2 + "\n" + chld.mkString("\n")
-          }.mkString("\n")
+          if (chld.isEmpty) h2 else h2 + "\n" + chld.mkString("\n")
         }.mkString("\n")
-    }.mkString("")
+      }.mkString("\n")
+    }.mkString("\n")
   }
 }

--- a/src/sbt-test/updateimpact/basic_13_8/expected.txt
+++ b/src/sbt-test/updateimpact/basic_13_8/expected.txt
@@ -110,31 +110,17 @@ com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
       org.apache.httpcomponents:httpclient:4.0.1
       org.scala-lang:scala-library:2.11.6
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
@@ -148,42 +134,23 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
       com.softwaremill.macwire:runtime_2.11:1.0.5
       javax.servlet:servlet-api:2.4
       org.scala-lang:scala-library:2.11.6
-   com.softwaremill.macwire:macros_2.11:1.0.5 evicted by exclude
    com.softwaremill.macwire:runtime_2.11:1.0.5
-      com.softwaremill.macwire:macros_2.11:1.0.5
       org.javassist:javassist:3.19.0-GA
       org.scala-lang:scala-library:2.11.6
-      org.scalatest:scalatest_2.11:2.2.5
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
    javax.servlet:servlet-api:2.4
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.javassist:javassist:3.19.0-GA
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   org.scalatest:scalatest_2.11:2.2.5 evicted by exclude
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT

--- a/src/sbt-test/updateimpact/basic_13_8/expected.txt
+++ b/src/sbt-test/updateimpact/basic_13_8/expected.txt
@@ -51,7 +51,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in compile
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in compile
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1
@@ -102,7 +103,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in runtime
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1

--- a/src/sbt-test/updateimpact/basic_13_9/expected.txt
+++ b/src/sbt-test/updateimpact/basic_13_9/expected.txt
@@ -110,31 +110,17 @@ com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
       org.apache.httpcomponents:httpclient:4.0.1
       org.scala-lang:scala-library:2.11.6
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
@@ -148,42 +134,23 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
       com.softwaremill.macwire:runtime_2.11:1.0.5
       javax.servlet:servlet-api:2.4
       org.scala-lang:scala-library:2.11.6
-   com.softwaremill.macwire:macros_2.11:1.0.5 evicted by exclude
    com.softwaremill.macwire:runtime_2.11:1.0.5
-      com.softwaremill.macwire:macros_2.11:1.0.5
       org.javassist:javassist:3.19.0-GA
       org.scala-lang:scala-library:2.11.6
-      org.scalatest:scalatest_2.11:2.2.5
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
    javax.servlet:servlet-api:2.4
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.javassist:javassist:3.19.0-GA
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   org.scalatest:scalatest_2.11:2.2.5 evicted by exclude
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT

--- a/src/sbt-test/updateimpact/basic_13_9/expected.txt
+++ b/src/sbt-test/updateimpact/basic_13_9/expected.txt
@@ -51,7 +51,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in compile
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in compile
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1
@@ -102,7 +103,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in runtime
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1

--- a/src/sbt-test/updateimpact/cached_13_8/expected.txt
+++ b/src/sbt-test/updateimpact/cached_13_8/expected.txt
@@ -110,31 +110,17 @@ com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
       org.apache.httpcomponents:httpclient:4.0.1
       org.scala-lang:scala-library:2.11.6
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
@@ -148,42 +134,23 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
       com.softwaremill.macwire:runtime_2.11:1.0.5
       javax.servlet:servlet-api:2.4
       org.scala-lang:scala-library:2.11.6
-   com.softwaremill.macwire:macros_2.11:1.0.5 evicted by exclude
    com.softwaremill.macwire:runtime_2.11:1.0.5
-      com.softwaremill.macwire:macros_2.11:1.0.5
       org.javassist:javassist:3.19.0-GA
       org.scala-lang:scala-library:2.11.6
-      org.scalatest:scalatest_2.11:2.2.5
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
    javax.servlet:servlet-api:2.4
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.javassist:javassist:3.19.0-GA
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   org.scalatest:scalatest_2.11:2.2.5 evicted by exclude
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT

--- a/src/sbt-test/updateimpact/cached_13_8/expected.txt
+++ b/src/sbt-test/updateimpact/cached_13_8/expected.txt
@@ -51,7 +51,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in compile
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in compile
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1
@@ -102,7 +103,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in runtime
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1

--- a/src/sbt-test/updateimpact/cached_13_9/expected.txt
+++ b/src/sbt-test/updateimpact/cached_13_9/expected.txt
@@ -110,31 +110,17 @@ com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
       org.apache.httpcomponents:httpclient:4.0.1
       org.scala-lang:scala-library:2.11.6
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
@@ -148,42 +134,23 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in test
       com.softwaremill.macwire:runtime_2.11:1.0.5
       javax.servlet:servlet-api:2.4
       org.scala-lang:scala-library:2.11.6
-   com.softwaremill.macwire:macros_2.11:1.0.5 evicted by exclude
    com.softwaremill.macwire:runtime_2.11:1.0.5
-      com.softwaremill.macwire:macros_2.11:1.0.5
       org.javassist:javassist:3.19.0-GA
       org.scala-lang:scala-library:2.11.6
-      org.scalatest:scalatest_2.11:2.2.5
    commons-codec:commons-codec:1.3
-      junit:junit:3.8.1
    commons-logging:commons-logging:1.1.1 evicted by 1.2
    commons-logging:commons-logging:1.2
-      junit:junit:3.8.1
    dom4j:dom4j:1.6.1
-      junitperf:junitperf:1.8
-      stax:stax-ri:1.0
-      xalan:xalan:2.5.1
-      xerces:xercesImpl:2.6.2
       xml-apis:xml-apis:1.0.b2
    javax.servlet:servlet-api:2.4
-   junit:junit:3.8.1 evicted by exclude
-   junit:junit:3.8.2 evicted by exclude
-   junitperf:junitperf:1.8 evicted by exclude
    log4j:log4j:1.2.14
    org.apache.httpcomponents:httpclient:4.0.1
       commons-codec:commons-codec:1.3
       commons-logging:commons-logging:1.1.1
-      junit:junit:3.8.2
       org.apache.httpcomponents:httpcore:4.0.1
    org.apache.httpcomponents:httpcore:4.0.1
-      junit:junit:3.8.1
    org.javassist:javassist:3.19.0-GA
-      junit:junit:3.8.1
    org.scala-lang:scala-library:2.11.6
-   org.scalatest:scalatest_2.11:2.2.5 evicted by exclude
-   stax:stax-ri:1.0 evicted by exclude
-   xalan:xalan:2.5.1 evicted by exclude
-   xerces:xercesImpl:2.6.2 evicted by exclude
    xml-apis:xml-apis:1.0.b2
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT

--- a/src/sbt-test/updateimpact/cached_13_9/expected.txt
+++ b/src/sbt-test/updateimpact/cached_13_9/expected.txt
@@ -51,7 +51,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in compile
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in compile
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1
@@ -102,7 +103,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in runtime
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       commons-logging:commons-logging:1.2
       dom4j:dom4j:1.6.1

--- a/src/sbt-test/updateimpact/range_13_8/expected.txt
+++ b/src/sbt-test/updateimpact/range_13_8/expected.txt
@@ -16,7 +16,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in compile
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in compile
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       log4j:log4j:1.2.11
       org.scala-lang:scala-library:2.11.6
@@ -34,7 +35,8 @@ com.softwaremill.example:module2_2.11:0.1-SNAPSHOT in runtime
 com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT in runtime
    com.softwaremill.example:sbt-example_2.11:0.1-SNAPSHOT
       org.scala-lang:scala-library:2.11.6
-   org.scala-lang:scala-library:2.11.6com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
+   org.scala-lang:scala-library:2.11.6
+com.softwaremill.example:module1_2.11:0.1-SNAPSHOT in test
    com.softwaremill.example:module1_2.11:0.1-SNAPSHOT
       log4j:log4j:1.2.11
       org.scala-lang:scala-library:2.11.6


### PR DESCRIPTION
No need for depending on fullClasspath task (dependencyClasspath is sufficient).